### PR TITLE
ERROR bar is now BoldRed

### DIFF
--- a/pygments_pytest.py
+++ b/pygments_pytest.py
@@ -37,8 +37,7 @@ class PytestLexer(pygments.lexer.RegexLexer):
             (r' +', pygments.token.Text),
         ],
         'failures': [
-            # note: ____ ERROR at setup of ... ____ is not red
-            (r'^_+ ((?!ERROR ).+) _+$', Color.BoldRed),
+            (r'^_+ .+ _+$', Color.BoldRed),
 
             (r'^E .*$', Color.BoldRed),
             (r'^[^:\n]+:\d+:.*$', filename_line),


### PR DESCRIPTION
I fixed this in https://github.com/pytest-dev/pytest/pull/4437