### PR TITLE
Fix Sphinx deprecation warning

### DIFF
--- a/pygments_pytest.py
+++ b/pygments_pytest.py
@@ -160,7 +160,7 @@ def setup(app: Any) -> None:  # pragma: no cover (sphinx)
         with open(path, 'w') as f:
             f.write(stylesheet(app.config.pygments_pytest_ansi_colors))
 
-    app.require_sphinx('1.0')
+    app.require_sphinx('1.8')
     app.add_config_value('pygments_pytest_ansi_colors', {}, 'html')
-    app.add_stylesheet('pygments_pytest.css')
+    app.add_css_file('pygments_pytest.css')
     app.connect('build-finished', copy_stylesheet)


### PR DESCRIPTION
It shows up when building pytest docs:

```console
$ sphinx-build -W --keep-going -b html doc/en doc/en/_build/html -t changelog_towncrier_draft
Running Sphinx v3.1.1
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/pygments_pytest.py:165: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('pygments_pytest.css')
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] reference
/Users/hugo/github/pytest/src/_pytest/python.py:docstring of _pytest.python.Metafunc.parametrize:1: WARNING: duplicate object description of _pytest.python.Metafunc.parametrize, other instance in reference, use :noindex: for one of them
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] reference
generating indices...  genindexdone
highlighting module code... [100%] pytest
writing additional pages...  searchdone
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build finished with problems, 1 warning.
```

Re:

> _Changed in version 1.8:_ Renamed from `app.add_stylesheet()`.

* https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file
* https://www.sphinx-doc.org/en/master/extdev/deprecated.html?highlight=add_stylesheet#deprecated-apis

Sphinx 1.0 was released in 2010 and 1.8 in 2018:

* https://pypi.org/project/Sphinx/#history

pytest itself uses a new enough Sphinx:

```
doc/en/requirements.txt:sphinx>=1.8.2,<2.1
```